### PR TITLE
詳細説明文を隠す

### DIFF
--- a/app/assets/stylesheets/properties.scss
+++ b/app/assets/stylesheets/properties.scss
@@ -24,7 +24,7 @@
 }
 
 #prop-details {
-  height: 15px;
+  height: 0px;
   overflow: hidden;
 
   &.open {


### PR DESCRIPTION
詳細説明の文が絶妙に見えていたので、show more ボタンの下に隠した。クリックすると表示される。
![スクリーンショット 2020-06-28 14 48 36](https://user-images.githubusercontent.com/63486181/85939231-9bc22100-b94e-11ea-8a8b-6b37dca725e5.png)
